### PR TITLE
Line linking

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -149,6 +149,13 @@ button:hover {
   display: flex;
   color: rgba(0,0,0,.3);
   border-right: 0.1rem solid #e1e1e1;
+  cursor: pointer;
+}
+
+:target .ghd-line-number,
+.ghd-line-type-add:target .ghd-line-number,
+.ghd-line-type-remove:target .ghd-line-number {
+  background-color: rgb(255, 251, 194);
 }
 
 .ghd-line-number-from {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,3 +21,19 @@ import { LiveSocket } from "phoenix_live_view"
 
 let liveSocket = new LiveSocket("/live", Socket, {})
 liveSocket.connect()
+
+
+/*
+Make it possible to click line numbers to update the address bar to a
+link directly to that line.
+*/
+const lines = document.querySelectorAll('.ghd-line-number')
+lines.forEach(line => {
+  line.addEventListener('click', e => {
+    const parent = line.parentNode
+
+    if (parent && parent.id) {
+      history.pushState(null, null, '#' + parent.id)
+    }
+  })
+})


### PR DESCRIPTION
Makes it possible to click the line numbers to update the URL. Loading the updated URL scrolls the page to that line and highlights it.

There are a lot of improvements possible here, but they take more JS magic. A future version would stop using hash+id to autoscroll, and do it manually instead (can center the highlighted line rather than putting it at the top of the viewport). Also making it possible to select multiple lines would be nice