### PR TITLE
Add spacing to diff lines

### DIFF
--- a/lib/diff_web/templates/render/render.html.eex
+++ b/lib/diff_web/templates/render/render.html.eex
@@ -31,7 +31,7 @@
                   </div>
                 </td>
                 <td class="ghd-text">
-                  <div class="ghd-text-internal"><%= line.text %></div>
+                  <div class="ghd-text-internal"><%= line_text(line.text) %></div>
                 </td>
               </tr>
             <% end %>

--- a/lib/diff_web/views/render_view.ex
+++ b/lib/diff_web/views/render_view.ex
@@ -37,4 +37,8 @@ defmodule DiffWeb.RenderView do
   end
 
   def line_type(line), do: to_string(line.type)
+
+  def line_text("+" <> text), do: "+ " <> text
+  def line_text("-" <> text), do: "- " <> text
+  def line_text(text), do: " " <> text
 end


### PR DESCRIPTION
Adds a bit of spacing, changing diff lines from eg `+const socket` to `+ const socket`.

This could also be solved in the diff parsing library