### PR TITLE
Clear the releases state in search view when a query has no results

### DIFF
--- a/lib/diff_web/live/search_view.ex
+++ b/lib/diff_web/live/search_view.ex
@@ -87,7 +87,8 @@ defmodule DiffWeb.SearchLiveView do
            not_found: "Package #{query} not found.",
            suggestions: suggestions,
            to: nil,
-           from: nil
+           from: nil,
+           releases: []
          )}
     end
   end


### PR DESCRIPTION
The `releases` property in the search view state wasn't getting reset when the user searched for a package that didn't exist, after search for a package that did. This caused a visual bug when a previous search result only had 1 version.

Fixes #30