### PR TITLE
Handle failures in the diff parsing same as other errors

### DIFF
--- a/lib/diff/hex/hex.ex
+++ b/lib/diff/hex/hex.ex
@@ -77,11 +77,12 @@ defmodule Diff.Hex do
            {:ok, tarball_to} <- get_tarball(package, to),
            :ok <- unpack_tarball(tarball_from, path_from),
            :ok <- unpack_tarball(tarball_to, path_to),
-           {:ok, gd} <- git_diff(path_from, path_to) do
-        GitDiff.parse_patch(gd)
+           {:ok, gd} <- git_diff(path_from, path_to),
+           {:ok, parsed} <- GitDiff.parse_patch(gd) do
+        {:ok, parsed}
       else
         error ->
-          Logger.error(inspect(error))
+          Logger.error("Failed to diff #{package} #{from}..#{to} with: #{inspect(error)}")
           {:error, :unknown}
       end
     after


### PR DESCRIPTION
`GitDiff.parse_patch` can fail, but that error wasn't managed. We can't really "recover", if the diff library doesn't support the diff then we have to fix the diff library. But we should at least present the correct error page!

Improves the error response from #35