### PR TITLE
Switch to Hex version of git_diff to use the latest release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Diff.MixProject do
       {:hex_core, "~> 0.6.1"},
       {:rollbax, "~> 0.11.0"},
       {:logster, "~> 1.0"},
-      {:git_diff, github: "mononym/git_diff"},
+      {:git_diff, "~> 0.6"},
       {:hackney, "~> 1.15"},
       {:floki, "~> 0.24.0"},
       {:mox, "~> 0.5.1", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
   "floki": {:hex, :floki, "0.24.0", "81ec04f66cdc7d142fa8c9f402e4493a25bf9eb8bc39f971f58a8ea84a2e35d3", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm"},
   "gettext": {:hex, :gettext, "0.17.0", "abe21542c831887a2b16f4c94556db9c421ab301aee417b7c4fbde7fbdbe01ec", [:mix], [], "hexpm"},
-  "git_diff": {:git, "https://github.com/mononym/git_diff.git", "c3431c6d37d51334a05a8fd72ea6ec038b916831", []},
+  "git_diff": {:hex, :git_diff, "0.6.0", "eb5bf991c9379487cb25a2a44fca63351f2b2ac33ec662a2a6d5f534f5f16fe5", [:mix], [], "hexpm"},
   "goth": {:hex, :goth, "1.2.0", "92d6d926065a72a7e0da8818cc3a133229b56edf378022c00d9886c4125ce769", [:mix], [{:httpoison, "~> 0.11 or ~> 1.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:joken, "~> 2.0", [hex: :joken, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.2", "07e33c794f8f8964ee86cebec1a8ed88db5070e52e904b8f12209773c1036085", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.5", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "hex_core": {:hex, :hex_core, "0.6.2", "180d53eb0e917f96d6350c19c45d8eada910e23237317e3e1f882aa7ceb20bc4", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Dogfooding ;) https://diff.hex.pm/diff/git_diff/0.5.1..0.6.0

Fixes #29
