### PR TITLE
Support implicit 'to' version as latest

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -12,4 +12,5 @@ config :goth, config: %{"project_id" => "diff"}
 config :logger, level: :warn
 
 config :diff,
-  package_store_impl: Diff.Package.StoreMock
+  package_store_impl: Diff.Package.StoreMock,
+  storage_impl: Diff.StorageMock

--- a/lib/diff_web/controllers/page_controller.ex
+++ b/lib/diff_web/controllers/page_controller.ex
@@ -61,8 +61,8 @@ defmodule DiffWeb.PageController do
     end
   end
 
-  defp parse_versions(versions) do
-    with [from, to] <- versions |> String.split("..") |> Enum.map(&String.trim/1),
+  defp parse_versions(input) do
+    with {:ok, [from, to]} <- versions_from_input(input),
          {:ok, from} <- parse_version(from),
          {:ok, to} <- parse_version(to) do
       {:ok, from, to}
@@ -71,6 +71,26 @@ defmodule DiffWeb.PageController do
         :error
     end
   end
+
+  defp versions_from_input(input) when is_binary(input) do
+    input
+    |> String.split("..")
+    |> case do
+      [from] ->
+        [from, ""]
+
+      [from, to] ->
+        [from, to]
+    end
+    |> versions_from_input()
+  end
+
+  defp versions_from_input([_from, _to] = versions) do
+    versions = Enum.map(versions, &String.trim/1)
+    {:ok, versions}
+  end
+
+  defp versions_from_input(_), do: :error
 
   defp parse_version(""), do: {:ok, :latest}
   defp parse_version(input), do: Version.parse(input)

--- a/lib/diff_web/controllers/page_controller.ex
+++ b/lib/diff_web/controllers/page_controller.ex
@@ -4,18 +4,43 @@ defmodule DiffWeb.PageController do
   require Logger
 
   def diff(conn, %{"package" => package, "versions" => versions}) do
-    case parse_versions(package, versions) do
+    case parse_versions(versions) do
       {:ok, from, to} ->
         do_diff(conn, package, from, to)
 
       :error ->
-        conn
-        |> put_status(400)
-        |> render("400.html")
+        render_error(conn, 400)
+    end
+  end
+
+  defp do_diff(conn, _package, version, version) do
+    render_error(conn, 400)
+  end
+
+  defp do_diff(conn, _package, :latest, _version) do
+    render_error(conn, 400)
+  end
+
+  defp do_diff(conn, package, from, :latest) do
+    case Diff.Package.Store.get_versions(package) do
+      {:ok, versions} ->
+        to =
+          versions
+          |> Enum.map(&Version.parse!/1)
+          |> Enum.filter(&(&1.pre == []))
+          |> Enum.max(Version)
+
+        do_diff(conn, package, from, to)
+
+      {:error, :not_found} ->
+        render_error(conn, 404)
     end
   end
 
   defp do_diff(conn, package, from, to) do
+    from = to_string(from)
+    to = to_string(to)
+
     case Diff.Storage.get(package, from, to) do
       {:ok, diff} ->
         Logger.debug("cache hit for #{inspect(package)}")
@@ -31,34 +56,28 @@ defmodule DiffWeb.PageController do
             render(conn, "diff.html", diff: rendered)
 
           {:error, :unknown} ->
-            render(conn, "500.html")
+            render_error(conn, 500)
         end
     end
   end
 
-  defp parse_versions(package, versions) do
+  defp parse_versions(versions) do
     with [from, to] <- versions |> String.split("..") |> Enum.map(&String.trim/1),
-         {:ok, from} <- parse_version(package, :from, from),
-         {:ok, to} <- parse_version(package, :to, to) do
-      {:ok, to_string(from), to_string(to)}
+         {:ok, from} <- parse_version(from),
+         {:ok, to} <- parse_version(to) do
+      {:ok, from, to}
     else
       _ ->
         :error
     end
   end
 
-  defp parse_version(_package, :from, ""), do: :error
+  defp parse_version(""), do: {:ok, :latest}
+  defp parse_version(input), do: Version.parse(input)
 
-  defp parse_version(package, :to, "") do
-    with {:ok, versions} <- Diff.Package.Store.get_versions(package) do
-      version =
-        versions
-        |> Enum.map(&Version.parse!/1)
-        |> Enum.max()
-
-      {:ok, version}
-    end
+  defp render_error(conn, status) do
+    conn
+    |> put_status(status)
+    |> render("#{status}.html")
   end
-
-  defp parse_version(_package, _kind, input), do: Version.parse(input)
 end

--- a/test/diff_web/controllers/page_controller_test.exs
+++ b/test/diff_web/controllers/page_controller_test.exs
@@ -1,8 +1,29 @@
 defmodule DiffWeb.PageControllerTest do
   use DiffWeb.ConnCase
+  import Mox
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
     assert html_response(conn, 200) =~ "<!DOCTYPE html>"
+  end
+
+  describe "GET /diff/:package/:versions" do
+    setup :verify_on_exit!
+
+    test "does not accept implicit from", %{conn: conn} do
+      conn = get(conn, "/diff/phoenix/%20..")
+      assert html_response(conn, 400) =~ "Bad request"
+    end
+
+    test "accepts implicit to", %{conn: conn} do
+      versions = ["1.4.5", "1.4.9", "1.5.0-rc.2"]
+      diff = "p403n1xd1ff"
+
+      expect(Diff.Package.StoreMock, :get_versions, fn "phoenix" -> {:ok, versions} end)
+      expect(Diff.StorageMock, :get, fn "phoenix", "1.4.5", "1.4.9" -> {:ok, diff} end)
+
+      conn = get(conn, "diff/phoenix/1.4.5..")
+      assert html_response(conn, 200) =~ diff
+    end
   end
 end

--- a/test/diff_web/controllers/page_controller_test.exs
+++ b/test/diff_web/controllers/page_controller_test.exs
@@ -22,7 +22,7 @@ defmodule DiffWeb.PageControllerTest do
       expect(Diff.Package.StoreMock, :get_versions, fn "phoenix" -> {:ok, versions} end)
       expect(Diff.StorageMock, :get, fn "phoenix", "1.4.5", "1.4.9" -> {:ok, diff} end)
 
-      conn = get(conn, "diff/phoenix/1.4.5..")
+      conn = get(conn, "diff/phoenix/1.4.5")
       assert html_response(conn, 200) =~ diff
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
+Mox.defmock(Diff.StorageMock, for: Diff.Storage)
 Mox.defmock(Diff.Package.StoreMock, for: Diff.Package.Store)


### PR DESCRIPTION
Hi there 👋

First, congrats for the feature, it's really cool!

I've been using the CLI diff for a bit, and the thing I usually want is:

**Show me the diff of the package from current installed version to latest _stable_ available.**

The currently installed version is known locally to the user (latest isn't), so it would be nice if the diff tool could accept a route with an implicit latest, so we can have a local command that opens quickly the browser.

What are your thoughts? 🙂

This code seems to do it nice, please tell me if you'd like any changes 👍

Thanks!