### PR TITLE
Update required min elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Diff.MixProject do
     [
       app: :diff,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
I run `mix test` using elixir 1.9.2 and it failed on this line https://github.com/hexpm/diff/blob/43708a4074fc6639011eeaac47bf2830cb006fd0/lib/diff_web/controllers/page_controller.ex#L33

Passing a module that implements `compare/2` as the sorting function to `Enum.map/2` is [available since 1.10](https://github.com/elixir-lang/elixir/commit/642a794ace79f8098187034f75455bf95de1e7fc#diff-6881431a92cd4e3ea0de82bf2338f8eaR1527-R1531)