### PR TITLE
Make headers sticky!

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -163,6 +163,11 @@ input.search-input:focus {
   padding: 10px;
   border-bottom: 0.1rem solid #e1e1e1;
   cursor: pointer;
+  background: #fff;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0px;
+  z-index: 1;
 }
 
 .ghd-file-header .reveal-diff {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,6 +50,10 @@ fileHeaders.forEach(header => {
     parent.querySelectorAll('.ghd-diff').forEach(diff => {
       diff.classList.toggle('hidden')
     })
-    header.classList.toggle('collapsed')
+    header.classList.toggle('collapsed') && scrollIfNeeded(header)
   })
 })
+
+const scrollIfNeeded = elem => {
+  elem.getBoundingClientRect().top < 0 && elem.scrollIntoView(true)
+}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Diff.MixProject do
     [
       app: :diff,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This small tweak sticks headers to be visible during the review of the diff, as a bonus now it's easier to collapse long file without scrolling back to its beginning.

_Inspired by GitHub's diffs view =)_

![sticky_header](https://user-images.githubusercontent.com/53276677/81660932-42c71980-93f0-11ea-97da-bb422518110a.gif)
