### PR TITLE
Remove maxlength from search field

### DIFF
--- a/lib/diff_web/templates/search/search.html.leex
+++ b/lib/diff_web/templates/search/search.html.leex
@@ -9,7 +9,6 @@
       name="q"
       value="<%= @query %>"
       placeholder="Search..."
-      maxlength="30"
     />
     <div class="suggestions">
       <%= if length(@suggestions) > 0 do %>


### PR DESCRIPTION
As there is no maxlength on hex.pm as noted by ericmj.

There are packages with names that are longer than 30 characters and the
user experience is confusing with the current limit.

Closes #55 
Possibly impacts #32