### PR TITLE
Put git metadata into unselectable spans

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -211,6 +211,15 @@ input.search-input:focus {
   text-transform: uppercase;
 }
 
+.ghd-line-status {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 .ghd-file-status-removed {
   color: red;
   border-color: red;
@@ -243,6 +252,14 @@ input.search-input:focus {
   cursor: pointer;
 }
 
+.ghd-line-number * {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
 .ghd-line.selected .ghd-line-number,
 .ghd-line.selected .ghd-line-number,
@@ -280,9 +297,17 @@ input.search-input:focus {
 
 .ghd-text-internal {
   white-space: pre;
+  padding: 0 90px;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.ghd-text-internal {
+.ghd-text-user {
+  white-space: pre;
   padding: 0 90px;
 }
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@
 use Mix.Config
 
 config :diff,
-  cache_version: 1,
+  cache_version: 2,
   package_store_impl: Diff.Package.DefaultStore
 
 # Configures the endpoint

--- a/lib/diff_web/templates/render/render.html.eex
+++ b/lib/diff_web/templates/render/render.html.eex
@@ -31,7 +31,7 @@
               </div>
             </td>
             <td class="ghd-text">
-              <div class="ghd-text-internal"><%= line_text(line.text) %></div>
+              <div class="ghd-text-user"><%= line_text(line.text) %></div>
             </td>
           </tr>
         <% end %>

--- a/lib/diff_web/views/render_view.ex
+++ b/lib/diff_web/views/render_view.ex
@@ -38,7 +38,8 @@ defmodule DiffWeb.RenderView do
 
   def line_type(line), do: to_string(line.type)
 
-  def line_text("+" <> text), do: "+ " <> text
-  def line_text("-" <> text), do: "- " <> text
-  def line_text(text), do: " " <> text
+  def line_text("+" <> text), do: [content_tag(:span, "+ ", class: "ghd-line-status"), content_tag(:span, text)]
+  def line_text("-" <> text), do: [content_tag(:span, "- ", class: "ghd-line-status"), content_tag(:span, text)]
+  def line_text(" " <> text), do: [content_tag(:span, "  ", class: "ghd-line-status"), content_tag(:span, text)]
+  def line_text(text), do: [content_tag(:span, text)]
 end

--- a/lib/diff_web/views/render_view.ex
+++ b/lib/diff_web/views/render_view.ex
@@ -38,8 +38,14 @@ defmodule DiffWeb.RenderView do
 
   def line_type(line), do: to_string(line.type)
 
-  def line_text("+" <> text), do: [content_tag(:span, "+ ", class: "ghd-line-status"), content_tag(:span, text)]
-  def line_text("-" <> text), do: [content_tag(:span, "- ", class: "ghd-line-status"), content_tag(:span, text)]
-  def line_text(" " <> text), do: [content_tag(:span, "  ", class: "ghd-line-status"), content_tag(:span, text)]
+  def line_text("+" <> text),
+    do: [content_tag(:span, "+ ", class: "ghd-line-status"), content_tag(:span, text)]
+
+  def line_text("-" <> text),
+    do: [content_tag(:span, "- ", class: "ghd-line-status"), content_tag(:span, text)]
+
+  def line_text(" " <> text),
+    do: [content_tag(:span, "  ", class: "ghd-line-status"), content_tag(:span, text)]
+
   def line_text(text), do: [content_tag(:span, text)]
 end


### PR DESCRIPTION
Currently, when trying to copy/paste the diffs from the browser into an editor, the line numbers and `-` and `+` are copied with it. I think generally folks don't want those when copying the diffs out of the browser.

This PR places that git metadata into unselectable spans. Since these adjust the HTML that is cached, I also bumped the cache_version which will bust the cache for all prior generated diffs. I didn't see a way to accomplish this without also changing the HTML.

![image](https://user-images.githubusercontent.com/643967/103839966-93b20f00-505e-11eb-80fc-7e487dfb5fa3.png)

Also comparing to GitHub:
![image](https://user-images.githubusercontent.com/643967/103840328-5306c580-505f-11eb-9b4b-4b40673d2eb2.png)

I also implemented this same change at https://utils.zest.dev/gendiff if you'd like to try it there.


Here's the before capture for copy/paste
```
665676 | encode(msg, callback){
-- | --
666 | -     let payload = [
667 | -       msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload
668 | -     ]
669 | -     return callback(JSON.stringify(payload))
677 | +     if(msg.payload.constructor === ArrayBuffer){
678 | +       return callback(this.binaryEncode(msg))
679 | +     } else {
680 | +       let payload = [msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload]
681 | +       return callback(JSON.stringify(payload))
682 | +     }
670683 | },
```

Here's the after

```
  encode(msg, callback){
    let payload = [
      msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload
    ]
    return callback(JSON.stringify(payload))
    if(msg.payload.constructor === ArrayBuffer){
      return callback(this.binaryEncode(msg))
    } else {
      let payload = [msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload]
      return callback(JSON.stringify(payload))
    }
  },
```


And here's what GitHub copies as a comparison point:

```
  encode(msg, callback){
    let payload = [
      msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload
    ]
    return callback(JSON.stringify(payload))
    if(msg.payload.constructor === ArrayBuffer){
      return callback(this.binaryEncode(msg))
    } else {
      let payload = [msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload]
      return callback(JSON.stringify(payload))
    }
  },
```



