### PR TITLE
Add link to package name on diffs page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -131,6 +131,19 @@ input.search-input:focus {
   background-color: white;
 }
 
+.package-name {
+  color: white;
+  padding: 2px 4px;
+}
+
+.package-name:hover {
+  color: #eee;
+  background: #714a94;
+  padding: 2px 4px;
+  border-radius: 5px;
+  border-color: #714a94;
+}
+
 .diff-button {
   background-color: #714a94;
   border-color: #714a94;

--- a/lib/diff_web/templates/page/diffs.html.eex
+++ b/lib/diff_web/templates/page/diffs.html.eex
@@ -1,8 +1,13 @@
 <div class="message-container">
   <table class="package-list">
     <tr><th>Package Name</th><th>From</th><th>To</th><th></th></tr>
-<%= for {app, from, to, link} <- @diffs do %>
-    <tr><td><%= app %></td><td><%= from %></td><td><%= to %></td><td><a href="<%= link %>" class="button diff-button">View Diff</a></td></tr>
-<% end %>
+    <%= for {app, from, to, link} <- @diffs do %>
+    <tr>
+      <td><a href="https://hex.pm/packages/<%= app %>" class="package-name"><%= app %></a></td>
+      <td><%= from %></td>
+      <td><%= to %></td>
+      <td><a href="<%= link %>" class="button diff-button">View Diff</a></td>
+    </tr>
+    <% end %>
 </table>
 </div>

--- a/lib/diff_web/templates/page/diffs.html.eex
+++ b/lib/diff_web/templates/page/diffs.html.eex
@@ -3,7 +3,7 @@
     <tr><th>Package Name</th><th>From</th><th>To</th><th></th></tr>
     <%= for {app, from, to, link} <- @diffs do %>
     <tr>
-      <td><a href="https://hex.pm/packages/<%= app %>" class="package-name"><%= app %></a></td>
+      <td><a href="https://hex.pm/packages/<%= app %>/<%= to %>" class="package-name"><%= app %></a></td>
       <td><%= from %></td>
       <td><%= to %></td>
       <td><a href="<%= link %>" class="button diff-button">View Diff</a></td>


### PR DESCRIPTION
Often when I use the diffs page, I wish there was a simple link to the package page on hex.pm

https://user-images.githubusercontent.com/36407/117719795-d4a46680-b1ab-11eb-82c6-dd61292fcf74.mov

Is this useful?