### PR TITLE
Display package name/versions in header and html title

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -344,6 +344,11 @@ input.search-input:focus {
   padding: 0 90px;
 }
 
+.package-header {
+  text-align: center;
+  color: #fff;
+}
+
 table.package-list tr:nth-child(even) {
   background-color: rgba(255, 255, 255, 0.06);
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -347,6 +347,13 @@ input.search-input:focus {
 .package-header {
   text-align: center;
   color: #fff;
+  margin-bottom: 0;
+}
+
+.package-sub-header {
+  text-align: center;
+  color: #fff;
+  word-spacing: 5px;
 }
 
 table.package-list tr:nth-child(even) {

--- a/lib/diff_web/controllers/page_controller.ex
+++ b/lib/diff_web/controllers/page_controller.ex
@@ -62,7 +62,7 @@ defmodule DiffWeb.PageController do
 
         conn
         |> put_resp_content_type("text/html")
-        |> stream_diff(stream)
+        |> stream_diff(stream, package, from, to)
 
       {:error, :not_found} ->
         Logger.debug("cache miss for #{package}/#{from}..#{to}")
@@ -81,7 +81,7 @@ defmodule DiffWeb.PageController do
 
         conn
         |> put_resp_content_type("text/html")
-        |> stream_diff(stream)
+        |> stream_diff(stream, package, from, to)
 
       :error ->
         render_error(conn, 500)
@@ -91,9 +91,11 @@ defmodule DiffWeb.PageController do
       render_error(conn, 500)
   end
 
-  defp stream_diff(conn, stream) do
+  defp stream_diff(conn, stream, package, from, to) do
+    header_assigns = [conn: conn, package: package, from: from, to: to]
+
     header = [
-      Phoenix.View.render_to_iodata(DiffWeb.LayoutView, "header.html", conn: conn),
+      Phoenix.View.render_to_iodata(DiffWeb.LayoutView, "header.html", header_assigns),
       Phoenix.View.render_to_iodata(DiffWeb.PageView, "diff_header.html", [])
     ]
 

--- a/lib/diff_web/templates/layout/header.html.eex
+++ b/lib/diff_web/templates/layout/header.html.eex
@@ -24,7 +24,7 @@
 
             <%= if @package do %>
               <h2 class="package-header"><%= @package %></h2>
-              <h3 class="package-sub-header"><%= @from %> &rarr; <%= @to %></h2>
+              <h3 class="package-sub-header"><%= @from %> &rarr; <%= @to %></h3>
             <% end %>
           </h1>
         </div>

--- a/lib/diff_web/templates/layout/header.html.eex
+++ b/lib/diff_web/templates/layout/header.html.eex
@@ -5,7 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="description" content="Web based diffs of Hex packages">
-    <title><%= @package %> hexdiff</title>
+    <%= if @package do %>
+      <title><%= @package %> <%= @from %>..<%= @to %> | hexdiff</title>
+    <% else %>
+      <title>hexdiff</title>
+    <% end %>
 
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
 

--- a/lib/diff_web/templates/layout/header.html.eex
+++ b/lib/diff_web/templates/layout/header.html.eex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="description" content="Web based diffs of Hex packages">
-    <title>hexdiff</title>
+    <title><%= @package %> hexdiff</title>
 
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
 
@@ -21,6 +21,10 @@
             <a href="/">
               <img src="<%= Routes.static_path(@conn, "/images/hexdiff.svg") %>" alt="hexdiff"/>
             </a>
+
+            <%= if @package do %>
+              <h2 class="package-header"><%= @package %> <%= @from %> &rarr; <%= @to %></h2>
+            <% end %>
           </h1>
         </div>
       </section>

--- a/lib/diff_web/templates/layout/header.html.eex
+++ b/lib/diff_web/templates/layout/header.html.eex
@@ -23,7 +23,8 @@
             </a>
 
             <%= if @package do %>
-              <h2 class="package-header"><%= @package %> <%= @from %> &rarr; <%= @to %></h2>
+              <h2 class="package-header"><%= @package %></h2>
+              <h3 class="package-sub-header"><%= @from %> &rarr; <%= @to %></h2>
             <% end %>
           </h1>
         </div>

--- a/lib/diff_web/views/layout_view.ex
+++ b/lib/diff_web/views/layout_view.ex
@@ -1,3 +1,11 @@
 defmodule DiffWeb.LayoutView do
   use DiffWeb, :view
+
+  def render("header.html", assigns) do
+    package = assigns[:package]
+    from = assigns[:from]
+    to = assigns[:to]
+    assigns = Map.merge(assigns, %{package: package, from: from, to: to})
+    render_template("header.html", assigns)
+  end
 end


### PR DESCRIPTION
Closes https://github.com/hexpm/diff/issues/77

Example:

<img width="1299" alt="Screen Shot 2022-04-26 at 11 06 53 PM" src="https://user-images.githubusercontent.com/7695024/165432719-b0b2bcd9-7dad-42fc-aa3d-3f4788de05b1.png">


